### PR TITLE
Release an underlying webview upon component unmount

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ allprojects {
 
 dependencies {
     ...
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.13'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.14'
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,55 +23,7 @@ yarn add react-native-pagecall
 
 ## Usage
 
-```jsx
-import React from 'react';
-import { useRef, useCallback } from 'react';
-
-import { StyleSheet, View, Button } from 'react-native';
-import { PagecallView } from 'react-native-pagecall';
-import type { PagecallViewRef } from 'react-native-pagecall';
-
-const uri = 'https://demo.pagecall.net/join/six-canvas/230417a?chime=0';
-
-export default function App() {
-  const viewRef = useRef<PagecallViewRef>(null);
-
-  const handleButtonClick = useCallback(() => {
-    if (!viewRef.current) return;
-    viewRef.current.sendMessage('Hello from React Native!');
-  }, [viewRef]);
-
-  const handleMessage = useCallback((message: string) => {
-    console.log('Received message from PagecallView:', message);
-  }, []);
-
-  return (
-    <View style={styles.container}>
-      <PagecallView
-        uri={uri}
-        style={styles.pagecallView}
-        ref={viewRef}
-        onMessage={handleMessage}
-      />
-      <View style={styles.buttonContainer}>
-        <Button title="Send Message" onPress={handleButtonClick} />
-      </View>
-    </View>
-  );
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  pagecallView: {
-    flex: 1,
-  },
-  buttonContainer: {
-    marginBottom: 16,
-  },
-});
-```
+Please refer to the example. You can easily grasp it by looking at [App.tsx](/example/src/App.tsx).
 
 ## Android setup
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # react-native-pagecall
 
-A React Native module that provides a simple WebView component to integrate Pagecall's audio feature into your application. Note that video feature is not supported yet.  
+A React Native module that provides a simple WebView component to integrate Pagecall's audio feature into your application. Note that video feature is not supported yet.
 
-It uses following native SDKs  
+It uses following native SDKs
 
 - [pagecall-android-sdk](https://github.com/pagecall/pagecall-android-sdk)
 - [pagecall-ios-sdk](https://github.com/pagecall/pagecall-ios-sdk)
@@ -15,7 +15,7 @@ It uses following native SDKs
 npm install react-native-pagecall
 ```
 
-or 
+or
 
 ```sh
 yarn add react-native-pagecall
@@ -75,9 +75,9 @@ const styles = StyleSheet.create({
 
 ## Android setup
 
-To use this module in an Android project, you need to add the dependency of `pagecall-android-sdk` manually:  
+To use this module in an Android project, you need to add the dependency of `pagecall-android-sdk` manually:
 
-In your android/app/build.gradle file, add the following:  
+In your android/app/build.gradle file, add the following:
 
 ```groovy
 allprojects {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.pagecall:pagecall-android-sdk:0.0.13'
+  implementation 'com.pagecall:pagecall-android-sdk:0.0.14'
   // activate below line if you want to use local sdk
   // implementation project(':pagecall-android-sdk')
 

--- a/android/src/main/java/com/pagecall/PagecallViewManager.java
+++ b/android/src/main/java/com/pagecall/PagecallViewManager.java
@@ -1,6 +1,5 @@
 package com.pagecallview;
 
-import android.graphics.Color;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -8,11 +7,9 @@ import androidx.annotation.NonNull;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
@@ -23,11 +20,8 @@ import java.util.Map;
 public class PagecallViewManager extends SimpleViewManager<View> {
   public static final String REACT_CLASS = "PagecallView";
 
-  private ReactApplicationContext reactContext;
-
   public PagecallViewManager(ReactApplicationContext reactContext) {
     super();
-    this.reactContext = reactContext;
   }
 
   @Override
@@ -40,7 +34,7 @@ public class PagecallViewManager extends SimpleViewManager<View> {
   @NonNull
   public View createViewInstance(ThemedReactContext reactContext) {
     PagecallWebView.setWebContentsDebuggingEnabled(true);
-    PagecallWebView webView = new PagecallWebView(reactContext);
+    PagecallWebView webView = new PagecallWebView(reactContext.getCurrentActivity());
     webView.listenMessage(message -> {
       reactContext
         .getJSModule(RCTEventEmitter.class)
@@ -57,8 +51,7 @@ public class PagecallViewManager extends SimpleViewManager<View> {
 
   @ReactProp(name = "uri")
   public void setUri(PagecallWebView view, String uri) {
-    PagecallWebView webView = (PagecallWebView) view;
-    webView.loadUrl(uri);
+    view.loadUrl(uri);
   }
 
   @Override

--- a/android/src/main/java/com/pagecall/PagecallViewManager.java
+++ b/android/src/main/java/com/pagecall/PagecallViewManager.java
@@ -34,7 +34,13 @@ public class PagecallViewManager extends SimpleViewManager<View> {
   @NonNull
   public View createViewInstance(ThemedReactContext reactContext) {
     PagecallWebView.setWebContentsDebuggingEnabled(true);
-    PagecallWebView webView = new PagecallWebView(reactContext.getCurrentActivity());
+    PagecallWebView webView = new PagecallWebView(reactContext.getCurrentActivity()) {
+      @Override
+      protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        this.destroy();
+      }
+    };
     webView.listenMessage(message -> {
       reactContext
         .getJSModule(RCTEventEmitter.class)

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -178,7 +178,7 @@ dependencies {
         implementation jscFlavor
     }
 
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.13'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.14'
     // activate when you use local sdk
     // implementation project(':pagecall-android-sdk')
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -78,7 +78,7 @@ PODS:
   - hermes-engine/Pre-built (0.71.7)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - Pagecall (0.0.11)
+  - Pagecall (0.0.12)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -330,8 +330,8 @@ PODS:
   - React-jsinspector (0.71.7)
   - React-logger (0.71.7):
     - glog
-  - react-native-pagecall (2.0.2):
-    - Pagecall (~> 0.0.11)
+  - react-native-pagecall (2.0.3):
+    - Pagecall (~> 0.0.12)
     - React-Core
   - React-perflogger (0.71.7)
   - React-RCTActionSheet (0.71.7):
@@ -595,7 +595,7 @@ SPEC CHECKSUMS:
   hermes-engine: 4438d2b8bf8bebaba1b1ac0451160bab59e491f8
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  Pagecall: f285669bd2333a9b56c97143e973d839e3148545
+  Pagecall: 7c9565ad429ce58f5e27f52311365a409bbaab90
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 5a4a30ac20c86eeadd6844a9328f78d4168cf9b2
   RCTTypeSafety: 279fc5861a89f0f37db3a585f27f971485b4b734
@@ -610,7 +610,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: eaa5f71eb8f6861cf0e57f1a0f52aeb020d9e18e
   React-jsinspector: 9885f6f94d231b95a739ef7bb50536fb87ce7539
   React-logger: 3f8ebad1be1bf3299d1ab6d7f971802d7395c7ef
-  react-native-pagecall: 548fb01242d178c48ad0bdd754a054241751716e
+  react-native-pagecall: 2814be6acf0f1ed83493141934414d279c821ecd
   React-perflogger: 2d505bbe298e3b7bacdd9e542b15535be07220f6
   React-RCTActionSheet: 0e96e4560bd733c9b37efbf68f5b1a47615892fb
   React-RCTAnimation: fd138e26f120371c87e406745a27535e2c8a04ef

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,8 @@
+/* eslint-disable react-native/no-inline-styles */
 import React from 'react';
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useState } from 'react';
 
-import { StyleSheet, View, Button } from 'react-native';
+import { View, Button } from 'react-native';
 import { PagecallView } from 'react-native-pagecall';
 import type { PagecallViewRef } from 'react-native-pagecall';
 
@@ -9,6 +10,7 @@ const uri = 'https://demo.pagecall.net/join/six-canvas/230417a?chime=0';
 
 export default function App() {
   const viewRef = useRef<PagecallViewRef>(null);
+  const [isOpen, setOpen] = useState(false);
 
   const handleButtonClick = useCallback(() => {
     if (!viewRef.current) return;
@@ -20,28 +22,25 @@ export default function App() {
   }, []);
 
   return (
-    <View style={styles.container}>
-      <PagecallView
-        uri={uri}
-        style={styles.pagecallView}
-        ref={viewRef}
-        onMessage={handleMessage}
-      />
-      <View style={styles.buttonContainer}>
+    <View style={{ flex: 1 }}>
+      {isOpen ? (
+        <PagecallView
+          uri={uri}
+          style={{ flex: 1 }}
+          ref={viewRef}
+          onMessage={handleMessage}
+        />
+      ) : (
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <Button title="Open" onPress={() => setOpen(true)} />
+        </View>
+      )}
+      <View
+        style={{ padding: 20, justifyContent: 'center', flexDirection: 'row' }}
+      >
         <Button title="Send Message" onPress={handleButtonClick} />
+        <Button title="Close" onPress={() => setOpen(false)} />
       </View>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  pagecallView: {
-    flex: 1,
-  },
-  buttonContainer: {
-    marginBottom: 16,
-  },
-});

--- a/ios/PagecallViewManager.m
+++ b/ios/PagecallViewManager.m
@@ -5,5 +5,6 @@
 RCT_EXPORT_VIEW_PROPERTY(uri, NSString)
 RCT_EXPORT_VIEW_PROPERTY(onNativeEvent, RCTDirectEventBlock)
 RCT_EXTERN_METHOD(sendMessage:(nonnull NSNumber *)viewID message:(NSString *)message)
+RCT_EXTERN_METHOD(dispose)
 
 @end

--- a/package.json
+++ b/package.json
@@ -94,7 +94,14 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "type-enum": [
+        1,
+        "always",
+        ["feat", "fix", "docs", "refactor", "test", "revert", "release", "chore"]
+      ]
+    }
   },
   "release-it": {
     "git": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pagecall",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A React Native module that provides a simple WebView component to integrate Pagecall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-pagecall.podspec
+++ b/react-native-pagecall.podspec
@@ -13,12 +13,11 @@ Pod::Spec.new do |s|
 
   s.platforms    = { :ios => "14.0" }
   s.source       = { :git => "https://github.com/pagecall/react-native-pagecall.git", :tag => "#{s.version}" }
-  s.source       = { :git => "https://github.com/pagecall/pagecall-ios-sdk.git" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Pagecall", '~> 0.0.11'
+  s.dependency "Pagecall", '~> 0.0.12'
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
## SDK 버전 업데이트
- [android@0.0.14](https://github.com/pagecall/pagecall-android-sdk/releases/tag/0.0.14) 1b745e681b3645e184cbf43d9beb75973e661662
  - 앱 크기를 줄이고 앱 JS 번들과 합쳐지는 것을 피합니다.
- [ios@0.0.12](https://github.com/pagecall/pagecall-ios-sdk/releases/tag/0.0.12) dc1995c
  - 유저에이전트로 SDK 버전을 표시합니다.

## 기타 버그수정
- 안드로이드 환경에서 권한이 없을 경우 묻지 않는 문제를 해결합니다. 61ecb01e3e83e236ba151475e7613101257d062c
- 언마운트되더라도 PagecallWebView 가 남아있는 문제를 해결합니다. 3e3433f

## 기타
- example에서 언마운트되는 케이스를 테스트할 수 있도록 합니다. 775c363
- whitespace 제거 7c04813
- docs 코드블록 대신 링크 055ce7d
- 커밋린트에서 `release` title 허용 d1eb986