### PR TITLE
consumer에서 proguard로 빌드하면 크래시가 나는 이슈 픽스

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ allprojects {
 
 dependencies {
     ...
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.14'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.15'
 }
 
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.pagecall:pagecall-android-sdk:0.0.14'
+  implementation 'com.pagecall:pagecall-android-sdk:0.0.15'
   // activate below line if you want to use local sdk
   // implementation project(':pagecall-android-sdk')
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -63,7 +63,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)
@@ -178,7 +178,7 @@ dependencies {
         implementation jscFlavor
     }
 
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.14'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.15'
     // activate when you use local sdk
     // implementation project(':pagecall-android-sdk')
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -330,7 +330,7 @@ PODS:
   - React-jsinspector (0.71.7)
   - React-logger (0.71.7):
     - glog
-  - react-native-pagecall (2.0.4):
+  - react-native-pagecall (2.0.5):
     - Pagecall (= 0.0.13)
     - React-Core
   - React-perflogger (0.71.7)
@@ -610,7 +610,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: eaa5f71eb8f6861cf0e57f1a0f52aeb020d9e18e
   React-jsinspector: 9885f6f94d231b95a739ef7bb50536fb87ce7539
   React-logger: 3f8ebad1be1bf3299d1ab6d7f971802d7395c7ef
-  react-native-pagecall: 9e248e6c3ab2742b453bdf5832d4afb5fe27d1a3
+  react-native-pagecall: c3b6cfd428a19930e63853841613c40125ecb799
   React-perflogger: 2d505bbe298e3b7bacdd9e542b15535be07220f6
   React-RCTActionSheet: 0e96e4560bd733c9b37efbf68f5b1a47615892fb
   React-RCTAnimation: fd138e26f120371c87e406745a27535e2c8a04ef

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pagecall",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A React Native module that provides a simple WebView component to integrate Pagecall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
- https://github.com/pagecall/pagecall-android-sdk/pull/13 를 반영합니다.
- example앱 릴리즈 빌드구성에서 proguard를 활성화해두었습니다.