### PR TITLE
Support event handlers / iOS SDK 0.0.15

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -78,7 +78,7 @@ PODS:
   - hermes-engine/Pre-built (0.71.7)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - Pagecall (0.0.13)
+  - Pagecall (0.0.15)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -331,7 +331,7 @@ PODS:
   - React-logger (0.71.7):
     - glog
   - react-native-pagecall (2.0.5):
-    - Pagecall (= 0.0.13)
+    - Pagecall (= 0.0.15)
     - React-Core
   - React-perflogger (0.71.7)
   - React-RCTActionSheet (0.71.7):
@@ -419,7 +419,7 @@ PODS:
     - React-perflogger (= 0.71.7)
   - RNCAsyncStorage (1.18.2):
     - React-Core
-  - SocketRocket (0.6.0)
+  - SocketRocket (0.6.1)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -600,7 +600,7 @@ SPEC CHECKSUMS:
   hermes-engine: 4438d2b8bf8bebaba1b1ac0451160bab59e491f8
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  Pagecall: 447c272d25a6326b02fa128e15392073aa606736
+  Pagecall: 3488f4fdbbd31e4730bf8ad0a829379a0b5c496f
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 5a4a30ac20c86eeadd6844a9328f78d4168cf9b2
   RCTTypeSafety: 279fc5861a89f0f37db3a585f27f971485b4b734
@@ -615,7 +615,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: eaa5f71eb8f6861cf0e57f1a0f52aeb020d9e18e
   React-jsinspector: 9885f6f94d231b95a739ef7bb50536fb87ce7539
   React-logger: 3f8ebad1be1bf3299d1ab6d7f971802d7395c7ef
-  react-native-pagecall: c3b6cfd428a19930e63853841613c40125ecb799
+  react-native-pagecall: 4f26e07e648e2d802dd521c36072d29ce8013958
   React-perflogger: 2d505bbe298e3b7bacdd9e542b15535be07220f6
   React-RCTActionSheet: 0e96e4560bd733c9b37efbf68f5b1a47615892fb
   React-RCTAnimation: fd138e26f120371c87e406745a27535e2c8a04ef
@@ -630,10 +630,10 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: c5c89f8f543842dd864b63ded1b0bbb9c9445328
   ReactCommon: dbfbe2f7f3c5ce4ce44f43f2fd0d5950d1eb67c5
   RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
-  SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
+  SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: d56980c8914db0b51692f55533409e844b66133c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 77d779f9b8f9cdb13435e864bb07695d84f24c83
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -70,6 +70,8 @@ export default function App() {
     return params;
   }, [query]);
 
+  const [isLoading, setLoading] = useState(false);
+
   if (!mode) {
     return (
       <View
@@ -98,10 +100,22 @@ export default function App() {
           />
           <View style={{ flexDirection: 'row', justifyContent: 'center' }}>
             <View style={{ marginRight: 16 }}>
-              <Button title="Meet" onPress={() => setMode('meet')} />
+              <Button
+                title="Meet"
+                onPress={() => {
+                  setLoading(true);
+                  setMode('meet');
+                }}
+              />
             </View>
             <View>
-              <Button title="Replay" onPress={() => setMode('replay')} />
+              <Button
+                title="Replay"
+                onPress={() => {
+                  setLoading(true);
+                  setMode('replay');
+                }}
+              />
             </View>
           </View>
         </View>
@@ -117,19 +131,39 @@ export default function App() {
         queryParams={queryParams}
         style={{ flex: 1 }}
         ref={viewRef}
+        onLoad={() => setLoading(false)}
+        onTerminate={() => setMode(null)}
         onMessage={setLatestMessage}
       />
-      <View
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          justifyContent: 'center',
-        }}
-      >
-        <Text>{latestMessage}</Text>
-      </View>
+      {latestMessage && (
+        <View
+          style={{
+            position: 'absolute',
+            bottom: 128,
+            left: 0,
+            right: 0,
+            alignItems: 'center',
+          }}
+        >
+          <Text style={{ color: 'red' }}>{latestMessage}</Text>
+        </View>
+      )}
+      {isLoading && (
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: '#1361FF',
+          }}
+        >
+          <Text style={{ color: 'white' }}>Now loading...</Text>
+        </View>
+      )}
       <View
         style={{ padding: 20, justifyContent: 'center', flexDirection: 'row' }}
       >

--- a/react-native-pagecall.podspec
+++ b/react-native-pagecall.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Pagecall", '0.0.13'
+  s.dependency "Pagecall", '0.0.15'
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
- https://github.com/pagecall/pagecall-ios-sdk/releases/tag/0.0.14 및 https://github.com/pagecall/pagecall-ios-sdk/releases/tag/0.0.15 를 적용합니다. 6f8b310
- `onMessage` 뿐 아니라 `onLoad`, `onError`, `onTerminate` 등의 이벤트 핸들러를 지원합니다. cf2f51e
- iOS에서 PDF 다운로드 기능을 지원합니다. e4fd585