### PR TITLE
안드로이드에서도 onLoad, onMessage, onTerminate 핸들러가 작동합니다.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.pagecall:pagecall-android-sdk:0.0.18'
+  implementation 'com.pagecall:pagecall-android-sdk:0.0.19'
   // activate below line if you want to use local sdk
   // implementation project(':pagecall-android-sdk')
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -178,7 +178,7 @@ dependencies {
         implementation jscFlavor
     }
 
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.18'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.19'
     // activate when you use local sdk
     // implementation project(':pagecall-android-sdk')
 


### PR DESCRIPTION
### 변경사항
- pagecall-android-sdk를 0.0.19로 업그레이드합니다.
- load, message, terminate 이벤트를 RN JS context로 프록싱합니다.

### 테스트

https://github.com/pagecall/react-native-pagecall/assets/20896042/708740bb-e73c-446f-9ac5-2c45bb32e4ff

