### PR TITLE
2.0.11 (iOS 0.0.17 -> 0.0.20, Android 0.0.25 -> 0.0.28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ allprojects {
 
 dependencies {
     ...
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.25'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.28'
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ allprojects {
 
 dependencies {
     ...
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.28'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.32'
 }
 
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.pagecall:pagecall-android-sdk:0.0.25'
+  implementation 'com.pagecall:pagecall-android-sdk:0.0.28'
   // activate below line if you want to use local sdk
   // implementation project(':pagecall-android-sdk')
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.pagecall:pagecall-android-sdk:0.0.28'
+  implementation 'com.pagecall:pagecall-android-sdk:0.0.32'
   // activate below line if you want to use local sdk
   // implementation project(':pagecall-android-sdk')
 

--- a/android/src/main/java/com/pagecall/PagecallViewManager.java
+++ b/android/src/main/java/com/pagecall/PagecallViewManager.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.util.Log;
 import android.view.View;
+import android.webkit.WebResourceError;
 
 import androidx.annotation.NonNull;
 
@@ -121,5 +122,12 @@ public class PagecallViewManager extends SimpleViewManager<View> implements Acti
     reactContext
       .getJSModule(RCTEventEmitter.class)
       .receiveEvent(webView.getId(), "onNativeEvent", createNativeEvent("terminate", "reason", reason));
+  }
+
+  @Override
+  public void onError(WebResourceError error) {
+    reactContext
+      .getJSModule(RCTEventEmitter.class)
+      .receiveEvent(webView.getId(), "onNativeEvent", createNativeEvent("terminate", "message", error.toString()));
   }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -178,7 +178,7 @@ dependencies {
         implementation jscFlavor
     }
 
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.28'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.32'
     // activate when you use local sdk
     // implementation project(':pagecall-android-sdk')
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -178,7 +178,7 @@ dependencies {
         implementation jscFlavor
     }
 
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.25'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.28'
     // activate when you use local sdk
     // implementation project(':pagecall-android-sdk')
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -330,7 +330,7 @@ PODS:
   - React-jsinspector (0.71.7)
   - React-logger (0.71.7):
     - glog
-  - react-native-pagecall (2.0.10):
+  - react-native-pagecall (2.0.11):
     - Pagecall (= 0.0.20)
     - React-Core
   - React-perflogger (0.71.7)
@@ -615,7 +615,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: eaa5f71eb8f6861cf0e57f1a0f52aeb020d9e18e
   React-jsinspector: 9885f6f94d231b95a739ef7bb50536fb87ce7539
   React-logger: 3f8ebad1be1bf3299d1ab6d7f971802d7395c7ef
-  react-native-pagecall: 1840493bcffc0271f0e5c02c23bd0aae70a4e91b
+  react-native-pagecall: 3e8c9cf00b1b2363ac75f9eb6ba6646908abd80c
   React-perflogger: 2d505bbe298e3b7bacdd9e542b15535be07220f6
   React-RCTActionSheet: 0e96e4560bd733c9b37efbf68f5b1a47615892fb
   React-RCTAnimation: fd138e26f120371c87e406745a27535e2c8a04ef

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -78,7 +78,7 @@ PODS:
   - hermes-engine/Pre-built (0.71.7)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - Pagecall (0.0.17)
+  - Pagecall (0.0.20)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -331,7 +331,7 @@ PODS:
   - React-logger (0.71.7):
     - glog
   - react-native-pagecall (2.0.10):
-    - Pagecall (= 0.0.17)
+    - Pagecall (= 0.0.20)
     - React-Core
   - React-perflogger (0.71.7)
   - React-RCTActionSheet (0.71.7):
@@ -600,7 +600,7 @@ SPEC CHECKSUMS:
   hermes-engine: 4438d2b8bf8bebaba1b1ac0451160bab59e491f8
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  Pagecall: 619269ba3d8a78a9339cc079d1f5b5cab30252ef
+  Pagecall: c7e68603cfdb17d2319db5314474d80d9dbfed05
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 5a4a30ac20c86eeadd6844a9328f78d4168cf9b2
   RCTTypeSafety: 279fc5861a89f0f37db3a585f27f971485b4b734
@@ -615,7 +615,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: eaa5f71eb8f6861cf0e57f1a0f52aeb020d9e18e
   React-jsinspector: 9885f6f94d231b95a739ef7bb50536fb87ce7539
   React-logger: 3f8ebad1be1bf3299d1ab6d7f971802d7395c7ef
-  react-native-pagecall: 1ff96b46ad366634a15f51e3b8233fa902faebf4
+  react-native-pagecall: 1840493bcffc0271f0e5c02c23bd0aae70a4e91b
   React-perflogger: 2d505bbe298e3b7bacdd9e542b15535be07220f6
   React-RCTActionSheet: 0e96e4560bd733c9b37efbf68f5b1a47615892fb
   React-RCTAnimation: fd138e26f120371c87e406745a27535e2c8a04ef
@@ -636,4 +636,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 77d779f9b8f9cdb13435e864bb07695d84f24c83
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pagecall",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "A React Native module that provides a simple WebView component to integrate Pagecall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-pagecall.podspec
+++ b/react-native-pagecall.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Pagecall", '0.0.17'
+  s.dependency "Pagecall", '0.0.20'
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
- iOS SDK 0.0.17 -> 0.0.20
- Android SDK 0.0.25 -> 0.0.32
  - Supports `onError` now