### PR TITLE
fix: downgrade yarn to workaround #9015

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,6 +8,11 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version-file: .nvmrc
+    
+    # https://github.com/yarnpkg/yarn/issues/9015 해결되면 지워도 됨
+    - name: Install Yarn
+      shell: bash
+      run: npm install -g yarn@1.22.19
 
     - name: Cache dependencies
       id: yarn-cache


### PR DESCRIPTION
- 한 3개월 전부터 CI workflow가 실패하고 있어서 픽스합니다.
  <img width="1347" alt="image" src="https://github.com/pagecall/react-native-pagecall/assets/20896042/22b66b2d-ee4d-4eb7-9f5b-8115513f8a96">
- yarn 문제이며 workaround로 버전을 낮춰놨습니다. 픽스되면 지워도 됩니다.
  reference: https://github.com/yarnpkg/yarn/issues/9015