### PR TITLE
fix: unable to run the example iOS app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
+.xcode.env.local
 
 # Android/IJ
 #

--- a/example/ios/.xcode.env.local
+++ b/example/ios/.xcode.env.local
@@ -1,2 +1,0 @@
-export NODE_BINARY=/var/folders/xz/0fpctn511ljcpv8f25ywj6nh0000gn/T/yarn--1710919800595-0.4526992067525759/node
-


### PR DESCRIPTION
- Unable to run the example iOS app.
- Add `.xcode.env.local` to `.gitignore` to workaround https://github.com/facebook/react-native/issues/42221#issuecomment-1895955415