### PR TITLE
2.0.18 with Chime SDK removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ allprojects {
 
 dependencies {
     ...
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.41'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.43'
 }
 
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.pagecall:pagecall-android-sdk:0.0.41'
+  implementation 'com.pagecall:pagecall-android-sdk:0.0.43'
   // activate below line if you want to use local sdk
   // implementation project(':pagecall-android-sdk')
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -126,7 +126,7 @@ dependencies {
     } else {
         implementation jscFlavor
     }
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.41'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.43'
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/ios/PagecallViewManager.swift
+++ b/ios/PagecallViewManager.swift
@@ -130,6 +130,7 @@ class PagecallView: UIView, PagecallDelegate, UIDocumentPickerDelegate {
     func dispose() {
         self.stopListen?()
         self.stopListen = nil
+        webView.cleanup()
     }
 
     deinit {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "^yarn@1.22.15",
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pagecall",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A React Native module that provides a simple WebView component to integrate Pagecall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-pagecall.podspec
+++ b/react-native-pagecall.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Pagecall", '0.0.22'
+  s.dependency "Pagecall", '0.0.25'
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
- iOS 0.0.22 -> 0.0.25
  - https://github.com/pagecall/pagecall-ios-sdk/releases/tag/0.0.23
  - https://github.com/pagecall/pagecall-ios-sdk/releases/tag/0.0.24
  - https://github.com/pagecall/pagecall-ios-sdk/releases/tag/0.0.25
- Android 0.0.41 -> 0.0.43
  - https://github.com/pagecall/pagecall-android-sdk/pull/64
  - https://github.com/pagecall/pagecall-android-sdk/pull/66