### PR TITLE
2.0.20 with Android wired headphones

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ allprojects {
 
 dependencies {
     ...
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.43'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.45'
 }
 
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.pagecall:pagecall-android-sdk:0.0.43'
+  implementation 'com.pagecall:pagecall-android-sdk:0.0.45'
   // activate below line if you want to use local sdk
   // implementation project(':pagecall-android-sdk')
 

--- a/android/src/main/java/com/pagecall/PagecallViewManager.java
+++ b/android/src/main/java/com/pagecall/PagecallViewManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 import com.pagecall.PagecallWebView;
 import com.pagecall.TerminationReason;
+import com.pagecall.PagecallError;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -233,10 +234,10 @@ public class PagecallViewManager extends SimpleViewManager<View> implements Acti
   }
 
   @Override
-  public void onError(WebResourceError error) {
+  public void onError(PagecallError error) {
     Log.d("PagecallViewManager", "onError");
     reactContext
       .getJSModule(RCTEventEmitter.class)
-      .receiveEvent(webView.getId(), "onNativeEvent", createNativeEvent("error", "message", error.getDescription().toString()));
+      .receiveEvent(webView.getId(), "onNativeEvent", createNativeEvent("error", "message", error.getMessage()));
   }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -126,7 +126,7 @@ dependencies {
     } else {
         implementation jscFlavor
     }
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.43'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.45'
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pagecall",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "A React Native module that provides a simple WebView component to integrate Pagecall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Fixes an issue introduced in #38 where wired earphones were not being used, and the speakerphone was used instead in Android devices.

- Refer to https://github.com/pagecall/pagecall-android-sdk/releases/tag/0.0.45