### PR TITLE
2.0.21 with Android usb outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ allprojects {
 
 dependencies {
     ...
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.45'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.46'
 }
 
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.pagecall:pagecall-android-sdk:0.0.45'
+  implementation 'com.pagecall:pagecall-android-sdk:0.0.46'
   // activate below line if you want to use local sdk
   // implementation project(':pagecall-android-sdk')
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -126,7 +126,7 @@ dependencies {
     } else {
         implementation jscFlavor
     }
-    implementation 'com.pagecall:pagecall-android-sdk:0.0.45'
+    implementation 'com.pagecall:pagecall-android-sdk:0.0.46'
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -945,7 +945,7 @@ PODS:
   - React-Mapbuffer (0.73.6):
     - glog
     - React-debug
-  - react-native-pagecall (2.0.18):
+  - react-native-pagecall (2.0.21):
     - Pagecall (= 0.0.26)
     - React-Core
   - React-nativeconfig (0.73.6)
@@ -1358,7 +1358,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 85583ef014ce53d731a98c66a0e24496f7a83066
   React-logger: 3eb80a977f0d9669468ef641a5e1fabbc50a09ec
   React-Mapbuffer: 84ea43c6c6232049135b1550b8c60b2faac19fab
-  react-native-pagecall: 7be8861f2fcbe19559e6c06899421b8bf1b9fc4c
+  react-native-pagecall: 25e2c2d79aeb560636af8d8f549b85fca4c013f7
   React-nativeconfig: b4d4e9901d4cabb57be63053fd2aa6086eb3c85f
   React-NativeModulesApple: cd26e56d56350e123da0c1e3e4c76cb58a05e1ee
   React-perflogger: 5f49905de275bac07ac7ea7f575a70611fa988f2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pagecall",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "description": "A React Native module that provides a simple WebView component to integrate Pagecall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Fixes an issue introduced in #41 where earphones connected via a USB port were not being recognized.

- Refer to https://github.com/pagecall/pagecall-android-sdk/releases/tag/0.0.46