### PR TITLE
2.0.24: Update Android SDK to 0.0.53 to resolve audio feedback issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.pagecall:pagecall-android-sdk:0.0.52'
+  implementation 'com.pagecall:pagecall-android-sdk:0.0.53'
   // activate below line if you want to use local sdk
   // implementation project(':pagecall-android-sdk')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pagecall",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "description": "A React Native module that provides a simple WebView component to integrate Pagecall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
This update resolves audio feedback issues reported on Android devices by incorporating the latest fixes from the Android SDK. (https://github.com/pagecall/pagecall-android-sdk/releases/tag/0.0.53)